### PR TITLE
Updating Deps

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -643,20 +643,20 @@
         },
         {
             "name": "pattern-lab/unified-asset-installer",
-            "version": "v0.5.5",
+            "version": "v0.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pattern-lab/unified-asset-installer.git",
-                "reference": "041235d51ad32beacf435fd6942d01029266de7e"
+                "reference": "ff77fa7032b310400bddc23583ca86d62afd117f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pattern-lab/unified-asset-installer/zipball/041235d51ad32beacf435fd6942d01029266de7e",
-                "reference": "041235d51ad32beacf435fd6942d01029266de7e",
+                "url": "https://api.github.com/repos/pattern-lab/unified-asset-installer/zipball/ff77fa7032b310400bddc23583ca86d62afd117f",
+                "reference": "ff77fa7032b310400bddc23583ca86d62afd117f",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "1.0.0",
+                "composer-plugin-api": "^1.0",
                 "php": ">=5.3.6"
             },
             "type": "composer-installer",
@@ -688,7 +688,7 @@
                 "pattern lab",
                 "plugins"
             ],
-            "time": "2015-03-02 14:02:04"
+            "time": "2016-05-12 00:32:50"
         },
         {
             "name": "pimple/pimple",
@@ -936,7 +936,7 @@
         },
         {
             "name": "symfony/process",
-            "version": "v2.8.5",
+            "version": "v2.8.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -1099,12 +1099,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/aleksip/plugin-data-transform.git",
-                "reference": "4dcce4ff0cfca29d1ede301dfe49ec7c4ea8a60a"
+                "reference": "527b5cec2cc44fb9d6f300003beff26cbb81127f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aleksip/plugin-data-transform/zipball/4dcce4ff0cfca29d1ede301dfe49ec7c4ea8a60a",
-                "reference": "4dcce4ff0cfca29d1ede301dfe49ec7c4ea8a60a",
+                "url": "https://api.github.com/repos/aleksip/plugin-data-transform/zipball/527b5cec2cc44fb9d6f300003beff26cbb81127f",
+                "reference": "527b5cec2cc44fb9d6f300003beff26cbb81127f",
                 "shasum": ""
             },
             "require": {
@@ -1136,7 +1136,7 @@
                 "pattern lab",
                 "plugin"
             ],
-            "time": "2016-05-06 05:08:11"
+            "time": "2016-05-11 14:38:38"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "15dae6cd352b0b1e7e7fdffd4288ec08",
-    "content-hash": "9bdb205bae4b69dab18ff706180fd56d",
+    "hash": "d4b8e585372ccb4f08a2c5208bcc55b8",
+    "content-hash": "060171ad43f004c8ce983bd5628dfc95",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -450,16 +450,16 @@
         },
         {
             "name": "pattern-lab/patternengine-twig",
-            "version": "v0.7.2",
+            "version": "v0.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pattern-lab/patternengine-php-twig.git",
-                "reference": "36242077104a0187deea0c00d18fef12861421bc"
+                "reference": "a97d76ce38c50b3f0d1c6580ef7e11bec4476030"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pattern-lab/patternengine-php-twig/zipball/36242077104a0187deea0c00d18fef12861421bc",
-                "reference": "36242077104a0187deea0c00d18fef12861421bc",
+                "url": "https://api.github.com/repos/pattern-lab/patternengine-php-twig/zipball/a97d76ce38c50b3f0d1c6580ef7e11bec4476030",
+                "reference": "a97d76ce38c50b3f0d1c6580ef7e11bec4476030",
                 "shasum": ""
             },
             "require": {
@@ -510,7 +510,7 @@
                 "pattern lab",
                 "twig"
             ],
-            "time": "2016-05-04 02:13:27"
+            "time": "2016-05-06 01:18:23"
         },
         {
             "name": "pattern-lab/styleguidekit-assets-default",
@@ -1099,15 +1099,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/aleksip/plugin-data-transform.git",
-                "reference": "0ca78f235acfc63796d97c5c675d18881672fe4d"
+                "reference": "4dcce4ff0cfca29d1ede301dfe49ec7c4ea8a60a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aleksip/plugin-data-transform/zipball/0ca78f235acfc63796d97c5c675d18881672fe4d",
-                "reference": "0ca78f235acfc63796d97c5c675d18881672fe4d",
+                "url": "https://api.github.com/repos/aleksip/plugin-data-transform/zipball/4dcce4ff0cfca29d1ede301dfe49ec7c4ea8a60a",
+                "reference": "4dcce4ff0cfca29d1ede301dfe49ec7c4ea8a60a",
                 "shasum": ""
             },
             "require": {
+                "pattern-lab/patternengine-twig": "0.*",
                 "php": ">=5.5.9"
             },
             "type": "patternlab-plugin",
@@ -1135,7 +1136,7 @@
                 "pattern lab",
                 "plugin"
             ],
-            "time": "2016-01-13 14:21:58"
+            "time": "2016-05-06 05:08:11"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
This updates these dependencies:

- Twig Engine: [`v0.7.2` => `v0.7.4`](https://github.com/pattern-lab/patternengine-php-twig/compare/v0.7.2...v0.7.4)
    - [v0.7.3](https://github.com/pattern-lab/patternengine-php-twig/releases/tag/v0.7.3) bring us Event Support
   - [v0.7.4](https://github.com/pattern-lab/patternengine-php-twig/releases/tag/v0.7.4) brings us the removal of NodeVisitor
- Data Transform Plugin with [these changes](https://github.com/aleksip/plugin-data-transform/compare/0ca78f235acfc63796d97c5c675d18881672fe4d...4dcce4ff0cfca29d1ede301dfe49ec7c4ea8a60a)

I'm curious if we should add these updates to our Edition, or if we should wait for some of the updates that @dmolsen has [mentioned in the "Consider dropping ./packages" for core](https://github.com/pattern-lab/patternlab-php-core/issues/14#issuecomment-217318692). Thoughts? /cc @aleksip 