### PR TITLE
require v3.0.0 of styleguidekit-twig-default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "php": ">=5.5.9",
         "pattern-lab/core": "^2.7.0",
         "pattern-lab/patternengine-twig": "^2.0.0",
-        "pattern-lab/styleguidekit-twig-default": "^2.0.0",
+        "pattern-lab/styleguidekit-twig-default": "^3.0.0",
         "pattern-lab/drupal-twig-components": "^2.0.0",
         "aleksip/plugin-data-transform": "^1.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name":             "bradwade/edition-drupal-standard",
+    "name":             "pattern-lab/edition-drupal-standard",
     "description":      "Standard Edition of Pattern Lab for Drupal.",
     "keywords":         ["pattern lab", "drupal"],
     "homepage":         "http://patternlab.io",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name":             "pattern-lab/edition-drupal-standard",
+    "name":             "bradwade/edition-drupal-standard",
     "description":      "Standard Edition of Pattern Lab for Drupal.",
     "keywords":         ["pattern lab", "drupal"],
     "homepage":         "http://patternlab.io",


### PR DESCRIPTION
This fixes html and twig display tabs when viewing pattern info and matches change made in Twig Standard edition. https://github.com/pattern-lab/edition-php-twig-standard